### PR TITLE
Remove bad clipboard patch

### DIFF
--- a/patches/@react-native-clipboard+clipboard+1.11.2.patch
+++ b/patches/@react-native-clipboard+clipboard+1.11.2.patch
@@ -1,0 +1,86 @@
+diff --git a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.cpp b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.cpp
+index d566a46..0b7ef28 100644
+--- a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.cpp
++++ b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.cpp
+@@ -8,7 +8,7 @@ namespace NativeClipboard {
+     if (dataPackageView.Contains(datatransfer::StandardDataFormats::Text())) {
+       dataPackageView.GetTextAsync().Completed([promise, dataPackageView](IAsyncOperation<winrt::hstring> info, AsyncStatus status) {
+         if (status == AsyncStatus::Completed) {
+-          auto text = Microsoft::Common::Unicode::Utf16ToUtf8(info.GetResults());
++          auto text = winrt::to_string(info.GetResults());
+           promise.Resolve(text);
+         }
+         else {
+@@ -22,8 +22,23 @@ namespace NativeClipboard {
+ 
+   void ClipboardModule::SetString(std::string const& str) noexcept
+   {
+-    datatransfer::DataPackage dataPackage{};
+-    dataPackage.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(str));
+-    datatransfer::Clipboard::SetContent(dataPackage);
++    _context.UIDispatcher().Post([str](){
++      datatransfer::DataPackage dataPackage{};
++      dataPackage.SetText(winrt::to_hstring(str));
++      datatransfer::Clipboard::SetContent(dataPackage);
++    });
++  }
++
++  void ClipboardModule::AddListener(std::string const& event) noexcept
++  {
++    _listenerCount++;
++  }
++
++  void ClipboardModule::RemoveListeners(int count) noexcept
++  {
++    _listenerCount--;
++    if (_listenerCount == 0) {
++      // Disconnect any native eventing here
++    }
+   }
+ }
+\ No newline at end of file
+diff --git a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.h b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.h
+index fdf68cf..7cf8566 100644
+--- a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.h
++++ b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.h
+@@ -16,11 +16,26 @@ namespace NativeClipboard {
+   REACT_MODULE(ClipboardModule, L"RNCClipboard");
+   struct ClipboardModule
+   {
++    REACT_INIT(Initialize);
++    void Initialize(const winrt::Microsoft::ReactNative::ReactContext& reactContext) noexcept
++    {
++      _context = reactContext;
++    }
+ 
+     REACT_METHOD(GetString, L"getString");
+     void GetString(React::ReactPromise<std::string>&& result) noexcept;
+ 
+     REACT_METHOD(SetString, L"setString");
+     void SetString(std::string const& str) noexcept;
++
++    REACT_METHOD(AddListener, L"addListener");
++    void AddListener(std::string const& event) noexcept;
++
++    REACT_METHOD(RemoveListeners, L"removeListeners");
++    void RemoveListeners(int count) noexcept;
++
++  private:
++    ReactContext _context;
++    int _listenerCount = 0;
+   };
+ }
+\ No newline at end of file
+diff --git a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.vcxproj b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.vcxproj
+index 4904b68..bf7dcfa 100644
+--- a/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.vcxproj
++++ b/node_modules/@react-native-clipboard/clipboard/windows/Clipboard/Clipboard.vcxproj
+@@ -14,7 +14,7 @@
+     <AppContainerApplication>true</AppContainerApplication>
+     <ApplicationType>Windows Store</ApplicationType>
+     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
++    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
+     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Was causing this issue:
```
× Build failed with message 9:10>C:\Users\cglein\Source\artificial-chat\node_modules\@react-native-clipboard\clipboard\windows\Clipboard\pch.cpp : fatal  error C1041: cannot open program database 'C:\Users\redacted\Source\artificial-chat\node_modules\@react-native-clipboard\clipboard\windows\Clipboard\x64\Debug\vc143.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS [C:\Users\redacted\Source\artificial-chat\node_modules\@react-native-clipboard\clipboard\windows\Clipboard\Clipboard.vcxproj]. Check your build configuration.
Command failed. Re-run the command with --logging for more information.
error Command failed with exit code 2302.
```