### PR TITLE
Add "read to me" menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ The app's settings are handled by a `SettingsContext` object, which has dialog U
 - Markdown rendering via [react-native-markdown-display-updated](https://github.com/willmac321/react-native-markdown-display)
 - Dialogs via [react-native-content-dialog](https://github.com/chrisglein/react-native-content-dialog)
 - Button, Checkbox, Link via [@fluentui/react-native](https://github.com/microsoft/fluentui-react-native)
+- Speech Synthesis via [react-native-winrt](https://github.com/microsoft/react-native-winrt)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-native-markdown-display-updated": "^7.0.0",
     "react-native-svg": "^15.1.0",
     "react-native-syntax-highlighter": "^2.1.0",
-    "react-native-windows": "0.73.10"
+    "react-native-windows": "0.73.10",
+    "react-native-winrt": "^0.72.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/patches/react-native-winrt+0.72.1.patch
+++ b/patches/react-native-winrt+0.72.1.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/react-native-winrt/windows/WinRTTurboModule/WinRTTurboModule.vcxproj b/node_modules/react-native-winrt/windows/WinRTTurboModule/WinRTTurboModule.vcxproj
+index 2271c03..0a24f0b 100644
+--- a/node_modules/react-native-winrt/windows/WinRTTurboModule/WinRTTurboModule.vcxproj
++++ b/node_modules/react-native-winrt/windows/WinRTTurboModule/WinRTTurboModule.vcxproj
+@@ -18,8 +18,6 @@
+     <AppContainerApplication>true</AppContainerApplication>
+     <ApplicationType>Windows Store</ApplicationType>
+     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+     <CppWinRTOptimized>true</CppWinRTOptimized>
+     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+@@ -28,6 +26,11 @@
+   <PropertyGroup Label="ReactNativeWindowsProps">
+     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+   </PropertyGroup>
++  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
++  <PropertyGroup Label="Fallback Windows SDK Versions">
++   <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
++   <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.17763.0</WindowsTargetPlatformMinVersion>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <ItemGroup Label="ProjectConfigurations">
+     <ProjectConfiguration Include="Debug|ARM">

--- a/src/AiResponse.tsx
+++ b/src/AiResponse.tsx
@@ -23,6 +23,7 @@ import {
 import { StylesContext } from './Styles';
 import { FeedbackContext } from './Feedback';
 import Clipboard from '@react-native-clipboard/clipboard';
+import Speak from './Speech';
 
 type AiImageResponseProps = {
   imageUrls?: string[];
@@ -98,6 +99,9 @@ function AiSection({children, id, isLoading, copyValue, moreMenu}: AiSectionProp
     menuItems.push(
       {title: "Copy to clipboard", icon: 0xE8C8, onPress: () => Clipboard.setString(copyValue)}
     );
+    menuItems.push(
+      {title: "Read to me", icon: 0xE995, onPress: () => { Speak(copyValue) } }
+    )
   }
   menuItems.push(
     {title: "👍 Give positive feedback", onPress: () => { showFeedbackPopup(true); }},

--- a/src/AiResponse.tsx
+++ b/src/AiResponse.tsx
@@ -23,7 +23,7 @@ import {
 import { StylesContext } from './Styles';
 import { FeedbackContext } from './Feedback';
 import Clipboard from '@react-native-clipboard/clipboard';
-import Speak from './Speech';
+import { Speak } from './Speech';
 
 type AiImageResponseProps = {
   imageUrls?: string[];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function App(): JSX.Element {
   const [imageSize, setImageSize] = React.useState<number>(256);
   const [showSettingsPopup, setShowSettingsPopup] = React.useState(false);
   const [showAboutPopup, setShowAboutPopup] = React.useState(false);
+  const [readToMeVoice, setReadToMeVoice] = React.useState<string | undefined>(undefined);
     
   const isDarkMode = currentTheme === 'dark';
   const styles = CreateStyles(isDarkMode);
@@ -50,6 +51,8 @@ function App(): JSX.Element {
     setAiEndpoint: setAiEndpoint,
     chatModel: chatModel,
     setChatModel: setChatModel,
+    readToMeVoice: readToMeVoice,
+    setReadToMeVoice: setReadToMeVoice,
   };
 
   const popups = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function App(): JSX.Element {
   const [imageSize, setImageSize] = React.useState<number>(256);
   const [showSettingsPopup, setShowSettingsPopup] = React.useState(false);
   const [showAboutPopup, setShowAboutPopup] = React.useState(false);
-  const [readToMeVoice, setReadToMeVoice] = React.useState<string | undefined>(undefined);
+  const [readToMeVoice, setReadToMeVoice] = React.useState<string>('');
     
   const isDarkMode = currentTheme === 'dark';
   const styles = CreateStyles(isDarkMode);

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -13,8 +13,9 @@ import {
   FeedbackPopup,
 } from './Feedback';
 import { PopupsContext } from './Popups';
-import { FlyoutMenuButton } from './Controls';
+import { SettingsContext } from './Settings';
 import { ButtonV1 as Button } from '@fluentui/react-native';
+import { Speak } from './Speech';
 
 enum ChatSource {
   Human,
@@ -110,6 +111,7 @@ function Chat({entries, humanText, onPrompt, clearConversation}: ChatProps): JSX
   const styles = React.useContext(StylesContext);
   const chatHistory = React.useContext(ChatHistoryContext);
   const popups = React.useContext(PopupsContext);
+  const settings = React.useContext(SettingsContext);
   const [showFeedbackPopup, setShowFeedbackPopup] = React.useState(false);
   const [feedbackTargetResponse, setFeedbackTargetResponse] = React.useState<string | undefined>(undefined);
   const [feedbackIsPositive, setFeedbackIsPositive] = React.useState(false);
@@ -130,6 +132,15 @@ function Chat({entries, humanText, onPrompt, clearConversation}: ChatProps): JSX
     setTimeout(() => {
       scrollViewRef.current?.scrollToEnd({animated: true});
     }, 100);
+  }
+
+  const onQueryResponse = (id: number, prompt: string, responses: string[], contentType: ChatContent) => {
+    chatHistory.modifyResponse(id, {prompt: prompt, responses: responses, contentType: contentType});
+    
+    // As the responses come in, speak them aloud (if enabled)
+    if (contentType == ChatContent.Text && settings.readToMeVoice) {
+      Speak(responses[0]);
+    }
   }
 
   return (
@@ -164,7 +175,7 @@ function Chat({entries, humanText, onPrompt, clearConversation}: ChatProps): JSX
                             prompt={entry.prompt ?? ""}
                             intent={entry.intent}
                             onResponse={({prompt, responses, contentType}) => 
-                              chatHistory.modifyResponse(entry.id, {prompt: prompt, responses: responses, contentType: contentType})}/>
+                              onQueryResponse(entry.id, prompt, responses, contentType)}/>
                   }
                 </View>
               ))}

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -40,7 +40,7 @@ type SettingsContextType = {
   chatModel: string,
   setChatModel: (value: string) => void,
   readToMeVoice: string,
-  setReadToMeVoice: (value: string | undefined) => void,
+  setReadToMeVoice: (value: string) => void,
 }
 const SettingsContext = React.createContext<SettingsContextType>({
   setApiKey: () => {},
@@ -114,7 +114,7 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
   const [detectImageIntent, setDetectImageIntent] = React.useState<boolean>(settings.detectImageIntent);
   const [imageResponseCount, setImageResponseCount] = React.useState<number>(settings.imageResponseCount);
   const [imageSize, setImageSize] = React.useState<number>(256);
-  const [readToMeVoice, setReadToMeVoice] = React.useState<string | undefined>(settings.readToMeVoice);
+  const [readToMeVoice, setReadToMeVoice] = React.useState<string>(settings.readToMeVoice);
 
   // It may seem weird to do this when the UI loads, not the app, but it's okay
   // because this component is loaded when the app starts but isn't shown. And
@@ -131,10 +131,9 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
       setImageSize(resolvedImageSize);
       settings.setImageSize(resolvedImageSize);
 
-      if (value.readToMeVoice !== undefined) {
-        settings.setReadToMeVoice(value.readToMeVoice);
-        SetVoice(value.readToMeVoice);
-      }
+      let resolvedReadToMeVoice = value.readToMeVoice ?? '';
+      settings.setReadToMeVoice(resolvedReadToMeVoice);
+      SetVoice(resolvedReadToMeVoice);
 
       // If an API key was set, continue to remember it
       setSaveApiKey(value.apiKey !== undefined);
@@ -152,11 +151,11 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
     settings.setImageResponseCount(imageResponseCount);
     settings.setImageSize(imageSize);
     settings.setReadToMeVoice(readToMeVoice);
-
+    
+    close();
+    
     // Need to apply to the speech engine
     SetVoice(readToMeVoice);
-
-    close();
 
     SaveSettingsData({
       apiKey: saveApiKey ? apiKey : undefined,
@@ -196,7 +195,7 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
   return (
     <ContentDialog
       show={show}
-      close={cancel}
+      close={() => {}}
       isLightDismissEnabled={false}
       title="OpenAI Settings"
       buttons={buttons}
@@ -256,7 +255,7 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
         <DialogSection header="Read to Me">
           <Text>Read to me</Text>
           <Picker
-            accessibilityLabel="Read to me voice"
+            accessibilityLabel="Read to me"
             selectedValue={readToMeVoice}
             onValueChange={value => setReadToMeVoice(value)}>
             {GetVoices().map(voice => <Picker.Item label={voice.displayName} value={voice.id} key={voice.id}/>)}

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Link,
   CheckboxV1 as Checkbox,
 } from '@fluentui/react-native';
+import { GetVoices, SetVoice } from './Speech';
 
 const settingsKey = 'settings';
 
@@ -38,6 +39,8 @@ type SettingsContextType = {
   setAiEndpoint: (value: string) => void,
   chatModel: string,
   setChatModel: (value: string) => void,
+  readToMeVoice: string,
+  setReadToMeVoice: (value: string | undefined) => void,
 }
 const SettingsContext = React.createContext<SettingsContextType>({
   setApiKey: () => {},
@@ -53,12 +56,15 @@ const SettingsContext = React.createContext<SettingsContextType>({
   setAiEndpoint: () => {},
   chatModel: '',
   setChatModel: () => {},
+  readToMeVoice: '',
+  setReadToMeVoice: () => {},
 });
 
 // Settings that are saved between app sessions
 type SettingsData = {
   apiKey?: string,
   imageSize?: number,
+  readToMeVoice?: string,
 }
 
 // Read settings from app storage
@@ -84,6 +90,7 @@ const LoadSettingsData = async () => {
       
       if (value.hasOwnProperty('apiKey')) { valueToSave.apiKey = value.apiKey; }
       if (value.hasOwnProperty('imageSize')) { valueToSave.imageSize = parseInt(value.imageSize); }
+      if (value.hasOwnProperty('readToMeVoice')) { valueToSave.readToMeVoice = value.readToMeVoice; }
     }
   } catch(e) {
     console.error(e);
@@ -107,6 +114,7 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
   const [detectImageIntent, setDetectImageIntent] = React.useState<boolean>(settings.detectImageIntent);
   const [imageResponseCount, setImageResponseCount] = React.useState<number>(settings.imageResponseCount);
   const [imageSize, setImageSize] = React.useState<number>(256);
+  const [readToMeVoice, setReadToMeVoice] = React.useState<string | undefined>(settings.readToMeVoice);
 
   // It may seem weird to do this when the UI loads, not the app, but it's okay
   // because this component is loaded when the app starts but isn't shown. And
@@ -123,6 +131,11 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
       setImageSize(resolvedImageSize);
       settings.setImageSize(resolvedImageSize);
 
+      if (value.readToMeVoice !== undefined) {
+        settings.setReadToMeVoice(value.readToMeVoice);
+        SetVoice(value.readToMeVoice);
+      }
+
       // If an API key was set, continue to remember it
       setSaveApiKey(value.apiKey !== undefined);
     }
@@ -138,12 +151,17 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
     settings.setDetectImageIntent(detectImageIntent);
     settings.setImageResponseCount(imageResponseCount);
     settings.setImageSize(imageSize);
+    settings.setReadToMeVoice(readToMeVoice);
+
+    // Need to apply to the speech engine
+    SetVoice(readToMeVoice);
 
     close();
 
     SaveSettingsData({
       apiKey: saveApiKey ? apiKey : undefined,
       imageSize: imageSize,
+      readToMeVoice: readToMeVoice,
     });
   }
 
@@ -156,6 +174,7 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
     setDetectImageIntent(settings.detectImageIntent);
     setImageResponseCount(settings.imageResponseCount);
     setImageSize(settings.imageSize);
+    setReadToMeVoice(settings.readToMeVoice);
     close();
   }
 
@@ -232,6 +251,16 @@ function SettingsPopup({show, close}: SettingsPopupProps): JSX.Element {
             selectedValue={imageSize}
             onValueChange={value => setImageSize(typeof value === 'number' ? value : parseInt(value))}>
             {[256, 512, 1024].map(size => <Picker.Item label={size.toString()} value={size} key={size}/>)}
+          </Picker>
+        </DialogSection>
+        <DialogSection header="Read to Me">
+          <Text>Read to me</Text>
+          <Picker
+            accessibilityLabel="Read to me voice"
+            selectedValue={readToMeVoice}
+            onValueChange={value => setReadToMeVoice(value)}>
+            {GetVoices().map(voice => <Picker.Item label={voice.displayName} value={voice.id} key={voice.id}/>)}
+            <Picker.Item label="None" value=""/>
           </Picker>
         </DialogSection>
         <DialogSection header="AI Scripts">

--- a/src/Speech.tsx
+++ b/src/Speech.tsx
@@ -1,7 +1,8 @@
 import 'react-native-winrt'
 
-export default async function Speak(text: string) {
-  let synth = new Windows.Media.SpeechSynthesis.SpeechSynthesizer();
+let synth = new Windows.Media.SpeechSynthesis.SpeechSynthesizer();
+
+async function Speak(text: string) {
   if (!synth) {
     console.log("error creating SpeechSynthesizer");
     return;
@@ -20,3 +21,44 @@ export default async function Speak(text: string) {
 
   // player.Dispose();
 }
+
+function GetVoices() {
+  if (!synth) {
+    console.log("error creating SpeechSynthesizer");
+    return;
+  }
+
+  // Get all of the installed voices.
+  let voices = Windows.Media.SpeechSynthesis.SpeechSynthesizer.allVoices;
+
+  // Get the currently selected voice.
+  let currentVoice = synth.voice;
+
+  let result = voices.map((voice) => {
+    return {
+      displayName: voice.displayName,
+      language: voice.language,
+      id: voice.id,
+      isCurrent: voice.id === currentVoice.id,
+    };
+  });
+
+  return result;
+}
+
+function SetVoice(voiceId: string | undefined) {
+  if (!synth) {
+    console.log("error creating SpeechSynthesizer");
+    return;
+  }
+
+  let voices = Windows.Media.SpeechSynthesis.SpeechSynthesizer.allVoices;
+  let voice = voices.find((voice) => voice.id === voiceId);
+  if (voice) {
+    synth.voice = voice;
+  } else {
+    synth.voice = Windows.Media.SpeechSynthesis.SpeechSynthesizer.defaultVoice;
+  }
+}
+
+export { Speak, GetVoices, SetVoice };

--- a/src/Speech.tsx
+++ b/src/Speech.tsx
@@ -1,0 +1,22 @@
+import 'react-native-winrt'
+
+export default async function Speak(text: string) {
+  let synth = new Windows.Media.SpeechSynthesis.SpeechSynthesizer();
+  if (!synth) {
+    console.log("error creating SpeechSynthesizer");
+    return;
+  }
+  
+  try {
+    let stream = await synth.synthesizeTextToStreamAsync(text);
+
+    let player = new Windows.Media.Playback.MediaPlayer();
+    let contentType = stream.contentType ?? 'audio/wav'; // Workaround for lack of contentType on stream type
+    player.source = Windows.Media.Core.MediaSource.createFromStream(stream, contentType);
+    player.play();
+  } catch (e) {
+    console.log(e);
+  }
+
+  // player.Dispose();
+}

--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -36,8 +36,6 @@
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
 
     <RnWinRTParameters>
-    -include Windows.UI.Notifications
-    -include Windows.Data.Xml.Dom
     -include Windows.Media.SpeechSynthesis
     -include Windows.Media.Playback
     -include Windows.Media.Core

--- a/windows/ExperimentalFeatures.props
+++ b/windows/ExperimentalFeatures.props
@@ -34,6 +34,14 @@
     <UseExperimentalNuget>false</UseExperimentalNuget>
 
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
+
+    <RnWinRTParameters>
+    -include Windows.UI.Notifications
+    -include Windows.Data.Xml.Dom
+    -include Windows.Media.SpeechSynthesis
+    -include Windows.Media.Playback
+    -include Windows.Media.Core
+    </RnWinRTParameters>
   
   </PropertyGroup>
 

--- a/windows/artificialChat.sln
+++ b/windows/artificialChat.sln
@@ -41,6 +41,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeAsyncStorage", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RNSVG", "..\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj", "{7ACF84EC-EFBA-4043-8E14-40B159508902}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinRTTurboModule", "..\node_modules\react-native-winrt\windows\WinRTTurboModule\WinRTTurboModule.vcxproj", "{E13C9C82-0013-422C-945E-848A258AC4DB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -179,6 +181,18 @@ Global
 		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x64.Build.0 = Release|x64
 		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x86.ActiveCfg = Release|Win32
 		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x86.Build.0 = Release|Win32
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|ARM64.Build.0 = Debug|ARM64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|x64.ActiveCfg = Debug|x64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|x64.Build.0 = Debug|x64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|x86.ActiveCfg = Debug|Win32
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Debug|x86.Build.0 = Debug|Win32
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|ARM64.ActiveCfg = Release|ARM64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|ARM64.Build.0 = Release|ARM64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|x64.ActiveCfg = Release|x64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|x64.Build.0 = Release|x64
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|x86.ActiveCfg = Release|Win32
+		{E13C9C82-0013-422C-945E-848A258AC4DB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/artificialChat/AutolinkedNativeModules.g.cpp
+++ b/windows/artificialChat/AutolinkedNativeModules.g.cpp
@@ -15,6 +15,9 @@
 // Includes from react-native-svg
 #include <winrt/RNSVG.h>
 
+// Includes from react-native-winrt
+#include <winrt/WinRTTurboModule.h>
+
 namespace winrt::Microsoft::ReactNative
 {
 
@@ -28,6 +31,8 @@ void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collecti
     packageProviders.Append(winrt::ReactNativePicker::ReactPackageProvider());
     // IReactPackageProviders from react-native-svg
     packageProviders.Append(winrt::RNSVG::ReactPackageProvider());
+    // IReactPackageProviders from react-native-winrt
+    packageProviders.Append(winrt::WinRTTurboModule::ReactPackageProvider());
 }
 
 }

--- a/windows/artificialChat/AutolinkedNativeModules.g.targets
+++ b/windows/artificialChat/AutolinkedNativeModules.g.targets
@@ -18,5 +18,9 @@
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj">
       <Project>{7acf84ec-efba-4043-8e14-40b159508902}</Project>
     </ProjectReference>
+    <!-- Projects from react-native-winrt -->
+    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-winrt\windows\WinRTTurboModule\WinRTTurboModule.vcxproj">
+      <Project>{E13C9C82-0013-422C-945E-848A258AC4DB}</Project>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/windows/artificialChat/packages.lock.json
+++ b/windows/artificialChat/packages.lock.json
@@ -94,6 +94,13 @@
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.UI.Xaml": "[2.8.0, )"
         }
+      },
+      "winrtturbomodule": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.ReactNative": "[1.0.0, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )"
+        }
       }
     },
     "native,Version=v0.0/win10-arm": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7740,6 +7740,11 @@ react-native-windows@0.73.10:
     ws "^6.2.2"
     yargs "^17.6.2"
 
+react-native-winrt@^0.72.1:
+  version "0.72.1"
+  resolved "https://registry.yarnpkg.com/react-native-winrt/-/react-native-winrt-0.72.1.tgz#d5b2bc0fe27080c03a85c33bd477b6da3e70f0f9"
+  integrity sha512-uhUAzKjOFpsfeoByBBA1FTgsCZuwLYN9y9C/Zg+StZRUYVBcqpOT46avwxHKkgWHN1ixoDc/jUFdE5lmV4DuoQ==
+
 react-native@0.73.0-rc.1:
   version "0.73.0-rc.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.73.0-rc.1.tgz#279f5f4ccdc3d43003310d22726efb89f03379f3"


### PR DESCRIPTION
Fixes #109

This adds two new features:
- A "read to me" menu option on any AI response.
- A "read to me" voice option in the settings menu. If set, all responses will automatically be read as they come in.

Can you do this with Narrator? Yes. The intent here however is less of an "all in" screen reader and more of a "voice chat" mode for the app. With this feature and Win+H for text entry, you shouldn't need to type and can go for a more "conversational" vibe.

![image](https://github.com/chrisglein/artificial-chat/assets/26607885/e34699c8-bb12-4c12-a63f-e9094586642d)


https://github.com/chrisglein/artificial-chat/assets/26607885/2b43ec85-13f3-4313-9263-cf4ab1f6981e

- [x] Add "read to me" menu item to AI responses
- [x] Add option to settings to always read responses as they come in
- [x] Add ability to customize the voice
- [ ] Add support for more modern natural voice options

Looks like the new Windows 11 "natural" voices aren't available from the local speech synthesizer (I think they're online only?). So stuck with the inbox voices for now. Future research:
- https://github.com/microsoft/cognitive-services-sdk-react-native-example
- https://github.com/microsoft/cognitive-services-speech-sdk-js?tab=readme-ov-file#installing
- https://github.com/Azure-Samples/cognitive-services-speech-sdk/blob/master/quickstart/csharp/uwp/text-to-speech/helloworld/MainPage.xaml.cs
- https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html
