### PR TITLE
Update to svg 15.3 to fix D2D unresolved external

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-native": "0.74.0-rc.9",
     "react-native-content-dialog": "^0.2.0",
     "react-native-markdown-display-updated": "^7.0.0",
-    "react-native-svg": "^15.1.0",
+    "react-native-svg": "^15.3.0",
     "react-native-syntax-highlighter": "^2.1.0",
     "react-native-windows": "0.74.0",
     "react-native-winrt": "^0.72.1"

--- a/patches/react-native-svg+15.3.0.patch
+++ b/patches/react-native-svg+15.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj b/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
-index 0fdeca0..9ab5fb9 100644
+index b682596..4f52dcf 100644
 --- a/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
 +++ b/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
 @@ -26,12 +26,10 @@
@@ -16,13 +16,3 @@ index 0fdeca0..9ab5fb9 100644
      <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.16299.0</WindowsTargetPlatformMinVersion>
    </PropertyGroup>
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-@@ -122,6 +120,9 @@
-     <ClCompile>
-       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-     </ClCompile>
-+    <Link>
-+      <AdditionalDependencies>dxguid.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-+    </Link>
-   </ItemDefinitionGroup>
-   <ItemGroup>
-     <ClInclude Include="BrushView.h" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,10 +7499,10 @@ react-native-markdown-display-updated@^7.0.0:
     prop-types "^15.7.2"
     react-native-fit-image "^1.5.5"
 
-react-native-svg@^15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.1.0.tgz#07c75f29b1d641faba50144c7ccd21604b368420"
-  integrity sha512-p0Sx0EpQNk1nu6UcMEiB8K9P04n3J7s+pNYUwf1d/Yz+v4hk961VjuVqjyndgiEbHZyWiKWLZRVNuvLpwjPY2A==
+react-native-svg@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.3.0.tgz#e24b833fe330714c99f1dd894bb0da52ad859a4c"
+  integrity sha512-mBHu/fdlzUbpGX8SZFxgbKvK/sgqLfDLP8uh8G7Us+zJgdjO8OSEeqHQs+kPRdQmdLJQiqPJX2WXgCl7ToTWqw==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
Fixes this error:

> ✖ Building Solution
[7752](https://github.com/chrisglein/artificial-chat/actions/runs/9653268129/job/26625269861?pr=149#step:6:7753)- Build failed with message ImageView.obj : error LNK2001: unresolved external symbol _CLSID_D2D12DAffineTransform [D:\a\artificial-chat\artificial-chat\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj]. Check your build configuration.
[7753](https://github.com/chrisglein/artificial-chat/actions/runs/9653268129/job/26625269861?pr=149#step:6:7754)✖ Build failed with message ImageView.obj : error LNK2001: unresolved external symbol _CLSID_D2D12DAffineTransform [D:\a\artificial-chat\artificial-chat\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj]. Check your build configuration.
