### PR TITLE
Reduce dependencies wrappers

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -9,7 +9,7 @@ import {
   DialogFrame,
 } from './Popups';
 import {StylesContext} from './Styles';
-import { VersionInfo } from './Dependencies'
+import VersionInfo from './NativeVersionInfo';
 
 type AboutPopupProps = {
   show: boolean;

--- a/src/AiResponse.tsx
+++ b/src/AiResponse.tsx
@@ -21,8 +21,8 @@ import {
 } from './Chat';
 import { StylesContext } from './Styles';
 import { FeedbackContext } from './Feedback';
-import { Clipboard } from './Dependencies';
-import { Markdown } from './Dependencies';
+import Clipboard from '@react-native-clipboard/clipboard';
+import Markdown from 'react-native-markdown-display';
 
 type AiImageResponseProps = {
   imageUrls?: string[];

--- a/src/CodeBlock.tsx
+++ b/src/CodeBlock.tsx
@@ -5,10 +5,10 @@ import {
   View,
 } from 'react-native';
 import { StylesContext } from './Styles';
-import { SyntaxHighlighter } from './Dependencies';
+import { SyntaxHighlighter } from 'react-native-syntax-highlighter';
 // See all styles here: https://highlightjs.org/static/demo/
-import { vs2015 } from './Dependencies';
-import { Clipboard } from './Dependencies';
+import { vs2015 } from 'react-syntax-highlighter/styles/hljs';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 function CodeBlock({content, language} : {content: string, language: string}): JSX.Element {
   const styles = React.useContext(StylesContext);

--- a/src/Dependencies.tsx
+++ b/src/Dependencies.tsx
@@ -4,13 +4,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import Clipboard from '@react-native-clipboard/clipboard';
-import Markdown from 'react-native-markdown-display';
 //import {Picker} from '@react-native-picker/picker';
-import { SyntaxHighlighter } from 'react-native-syntax-highlighter';
-import { vs2015 } from 'react-syntax-highlighter/styles/hljs';
-import VersionInfo from './NativeVersionInfo';
 
 type PickerItemProps = {
   label: string,
@@ -79,4 +73,4 @@ class Picker extends React.Component<PickerProps> {
   }
 }
 
-export { AsyncStorage, Clipboard, Markdown, Picker, SyntaxHighlighter, vs2015, VersionInfo }
+export { Picker }

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -16,7 +16,7 @@ import {
 import {StylesContext} from './Styles';
 import {Picker} from './Dependencies';
 import {ChatScriptNames} from './ChatScript';
-import {AsyncStorage} from './Dependencies';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const settingsKey = 'settings';
 


### PR DESCRIPTION
Replacing in-app native module used before clipboard was ready for new arch Windows